### PR TITLE
fix: Taskプロパティのファイル表示エリアでディレクトリの▶アイコンを表示する

### DIFF
--- a/client/src/components/common/innerTreeview.vue
+++ b/client/src/components/common/innerTreeview.vue
@@ -14,19 +14,21 @@
           :class="{'text-primary font-weight-bold selected-item': activatable && active !== null && active[itemKey] === item[itemKey]}"
         >
           <template #prepend>
-            <v-icon
+            <span
               v-bind="props"
-              :icon="getExpandIcon(isOpen)"
-              data-cy="inner_treeview-expand-icon"
+              class="d-inline-flex align-center"
               @click.stop="() => { if (!isOpen) { onClickNodeIcon(item); } }"
-            />
-            <v-icon
-              v-if="getNodeIcon(isOpen, item)"
-              v-bind="props"
-              :icon="getNodeIcon(isOpen, item)"
-              data-cy="inner_treeview-node-icon"
-              @click.stop="() => { if (!isOpen) { onClickNodeIcon(item); } }"
-            />
+            >
+              <v-icon
+                :icon="getExpandIcon(isOpen)"
+                data-cy="inner_treeview-expand-icon"
+              />
+              <v-icon
+                v-if="getNodeIcon(isOpen, item)"
+                :icon="getNodeIcon(isOpen, item)"
+                data-cy="inner_treeview-node-icon"
+              />
+            </span>
           </template>
           <div @click="(e) => { if (!isOpen) { props.onClick(e); onClickNodeIcon(item); } onActiveted(item); }">
             <slot

--- a/client/src/components/common/innerTreeview.vue
+++ b/client/src/components/common/innerTreeview.vue
@@ -16,7 +16,15 @@
           <template #prepend>
             <v-icon
               v-bind="props"
+              :icon="getExpandIcon(isOpen)"
+              data-cy="inner_treeview-expand-icon"
+              @click.stop="() => { if (!isOpen) { onClickNodeIcon(item); } }"
+            />
+            <v-icon
+              v-if="getNodeIcon(isOpen, item)"
+              v-bind="props"
               :icon="getNodeIcon(isOpen, item)"
+              data-cy="inner_treeview-node-icon"
               @click.stop="() => { if (!isOpen) { onClickNodeIcon(item); } }"
             />
           </template>
@@ -98,6 +106,12 @@
 </template>
 <script>
 
+//always-shown expand/collapse indicator for directory-like (expandable) nodes.
+//kept separate from getNodeIcon so callers can add their own icon (e.g. folder icon)
+//alongside this indicator instead of replacing it.
+const nodeOpenIcon = "mdi-menu-down";
+const nodeCloseIcon = "mdi-menu-right";
+
 export default {
   name: "InnerTreeview",
   props: {
@@ -136,6 +150,9 @@ export default {
   },
   emits: ["update:active"],
   methods: {
+    getExpandIcon(isOpen) {
+      return isOpen ? nodeOpenIcon : nodeCloseIcon;
+    },
     async onClickNodeIcon(item) {
       if (!this.loadChildren) {
         return false;

--- a/client/src/components/common/myTreeview.vue
+++ b/client/src/components/common/myTreeview.vue
@@ -45,9 +45,6 @@
 <script>
 import innerTreeview from "../../components/common/innerTreeview.vue";
 
-const nodeOpenIcon = "mdi-menu-down";
-const nodeCloseIcon = "mdi-menu-right";
-
 export default {
   name: "MyTreeview",
   components: {
@@ -74,9 +71,11 @@ export default {
       type: String,
       default: "id"
     },
+    //note: the expand/collapse indicator (▶/▼) itself is always rendered by innerTreeview.vue.
+    //getNodeIcon is only used for an additional, caller-specific icon (e.g. folder icon) shown next to it.
     getNodeIcon: {
       type: Function,
-      default: (isOpen)=>{ return isOpen ? nodeOpenIcon : nodeCloseIcon; }
+      default: ()=>{ return ""; }
     },
     getLeafIcon: {
       type: Function,

--- a/test/cypress/e2e/components/task.cy.js
+++ b/test/cypress/e2e/components/task.cy.js
@@ -661,6 +661,7 @@ describe("components", ()=>{
       //directory has no contents yet: the ▶(closed) expand icon must still be shown next to the directory icon
       cy.contains("[data-cy=\"file_browser-treeview-treeview\"] .v-list-item", "test-a")
         .find("[data-cy=\"inner_treeview-expand-icon\"]")
+        .scrollIntoView()
         .should("be.visible")
         .and("have.class", "mdi-menu-right");
       cy.get("[data-cy=\"file_browser-treeview-treeview\"]").contains("test-a")
@@ -671,6 +672,7 @@ describe("components", ()=>{
       //directory now has a file inside it: the expand icon must still be shown next to the directory icon
       cy.contains("[data-cy=\"file_browser-treeview-treeview\"] .v-list-item", "test-a")
         .find("[data-cy=\"inner_treeview-expand-icon\"]")
+        .scrollIntoView()
         .should("be.visible");
     });
 

--- a/test/cypress/e2e/components/task.cy.js
+++ b/test/cypress/e2e/components/task.cy.js
@@ -651,6 +651,31 @@ describe("components", ()=>{
 
     /**
   Task コンポーネントの基本機能動作確認
+  コンポーネント共通機能確認
+  ファイル操作エリア
+  ディレクトリの展開アイコン表示
+  試験確認内容：格納オブジェクトの有無に関わらずディレクトリアイコンの横に▶アイコンが表示されることを確認(issue#941)
+     */
+    it("ファイル操作エリア-ディレクトリの展開アイコン表示-ディレクトリアイコンの横に▶アイコンが表示されることを確認", ()=>{
+      cy.createDirOrFile(TYPE_DIR, "test-a", true);
+      //directory has no contents yet: the ▶(closed) expand icon must still be shown next to the directory icon
+      cy.contains("[data-cy=\"file_browser-treeview-treeview\"] .v-list-item", "test-a")
+        .find("[data-cy=\"inner_treeview-expand-icon\"]")
+        .should("be.visible")
+        .and("have.class", "mdi-menu-right");
+      cy.get("[data-cy=\"file_browser-treeview-treeview\"]").contains("test-a")
+        .click();
+      cy.createDirOrFile(TYPE_FILE, "test.txt", false);
+      cy.get("[data-cy=\"file_browser-treeview-treeview\"]").contains("test.txt")
+        .should("exist");
+      //directory now has a file inside it: the expand icon must still be shown next to the directory icon
+      cy.contains("[data-cy=\"file_browser-treeview-treeview\"] .v-list-item", "test-a")
+        .find("[data-cy=\"inner_treeview-expand-icon\"]")
+        .should("be.visible");
+    });
+
+    /**
+  Task コンポーネントの基本機能動作確認
   Taskコンポーネント機能確認
   プロパティ設定確認
   script表示確認


### PR DESCRIPTION
## 概要 (Summary)

GitLab issue #941 対応。

Taskコンポーネントのプロパティ画面、Filesエリアのファイルツリーで、ディレクトリノードの展開/折りたたみを示す ▶ / ▼ アイコンが、格納オブジェクトの有無によらず一切表示されない不具合を修正しました。ディレクトリアイコンをクリックすると展開自体は機能していましたが、視覚的なインジケータが欠落していました。

## 原因 (Root cause)

`client/src/components/common/innerTreeview.vue` はディレクトリノードの `prepend` 領域に `getNodeIcon()` が返す**単一の**アイコンだけを描画していました。`fileBrowser.vue` / `remoteFileBrowser.vue` はこの `getNodeIcon` をフォルダ開閉アイコン (`mdi-folder` / `mdi-folder-open`) 用に上書きしていたため、本来の展開インジケータ (`mdi-menu-right` / `mdi-menu-down`、デフォルト値としてのみ存在) が完全に消えていました。クリックによるトグル自体は `v-list-group` の activator props がこの単一アイコンにバインドされていたため機能していました。

## 修正内容 (Changes)

- `client/src/components/common/innerTreeview.vue`: 展開/折りたたみインジケータ (▶/▼) を常に描画するようにし、`getNodeIcon` は呼び出し元が追加で表示したい任意のアイコン (例: フォルダアイコン) として扱うように変更。両アイコンをラップする `<span>` に `v-list-group` の activator props (クリックハンドラ、id 等) を一度だけバインドし、重複 id が発生しないようにした。
- `client/src/components/common/myTreeview.vue`: `getNodeIcon` のデフォルト値を、常時表示される展開インジケータと重複しないよう空文字列に変更 (componentTree.vue 等、`getNodeIcon` を明示的に渡さない既存呼び出し元の見た目は変化なし)。
- `test/cypress/e2e/components/task.cy.js`: ディレクトリ作成直後 (中身が空の状態) と、ディレクトリ内にファイルを作成した後の両方で ▶ アイコンが表示されることを検証する e2e テストを追加。

## テスト計画 (Test plan)

- [x] `npm run lint` (変更ファイルはエラーなし。行番号1220付近の未関連ファイルの既存lintエラーは今回のdiffに含まれていません)
- [x] `npm run build` (クライアントビルド成功)
- [x] ローカルで `npm run -w test test:e2e:mock:start` → `npx cypress run --browser chrome --spec cypress/e2e/components/task.cy.js` → `npm run -w test test:e2e:mock:stop` を実施し、新規追加テストを含む task.cy.js の77テスト中76件がpassすることを確認 (残り1件は本修正と無関係な既存のflaky test: ジョブ実行完了待ちのタイムアウト)。
- CI (GitHub Actions) 上でも同様に確認済み。`run UT` の `backup` ジョブ失敗はこのフォーク既知の意図的な既知事象 (シークレット未設定) のため無視。

Fixes RIKEN-RCCS/OPEN-WHEEL#941