### PR TITLE
fix: autofocus new-file/rename and inputFile add-field text inputs

### DIFF
--- a/client/src/components/common/listForm.vue
+++ b/client/src/components/common/listForm.vue
@@ -75,8 +75,8 @@
       #bottom
     >
       <v-text-field
+        ref="addField"
         v-model.lazy="inputField"
-        :autofocus="autofocus"
         :rules="newItemValidator"
         :disabled="disabled"
         variant="outlined"
@@ -244,6 +244,14 @@ export default {
     if (this.additionalRules.length > 0) {
       this.updateItemValidator.push(...this.additionalRules);
       this.newItemValidator.push(...this.additionalRules);
+    }
+    if (this.autofocus) {
+      //Focus once, right after mount, instead of vuetify's built-in intersection-based
+      //autofocus: that fires on an animation frame, which can race with a sibling
+      //list-form (e.g. output files) also being interacted with while this panel opens.
+      this.$nextTick().then(()=>{
+        this.$refs.addField?.focus();
+      });
     }
   },
   methods: {

--- a/client/src/components/common/listForm.vue
+++ b/client/src/components/common/listForm.vue
@@ -76,6 +76,7 @@
     >
       <v-text-field
         v-model.lazy="inputField"
+        :autofocus="autofocus"
         :rules="newItemValidator"
         :disabled="disabled"
         variant="outlined"
@@ -139,6 +140,10 @@ export default {
     inputColumn: {
       type: Boolean,
       default: true
+    },
+    autofocus: {
+      type: Boolean,
+      default: false
     },
     selectable: {
       type: Boolean,

--- a/client/src/components/componentProperty.vue
+++ b/client/src/components/componentProperty.vue
@@ -374,6 +374,7 @@
               :headers="inputFileHeaders"
               :boolean-columns="['mandatory']"
               :show-headers="true"
+              autofocus
               data-cy="component_property-input_files_viewer-list_form"
               @add="addToInputFiles"
               @remove="removeFromInputFiles"
@@ -590,6 +591,7 @@
               :headers="inputFileHeaders"
               :boolean-columns="['mandatory']"
               :show-headers="true"
+              autofocus
               data-cy="component_property-input_files-list_form"
               @add="addToInputFiles"
               @remove="removeFromInputFiles"

--- a/client/src/components/fileBrowser.vue
+++ b/client/src/components/fileBrowser.vue
@@ -148,6 +148,7 @@
         <v-text-field
           v-if="['createNewDir','createNewFile','rename'].includes(dialog.submitEvent)"
           v-model="dialog.inputField"
+          autofocus
           :label="dialog.inputFieldLabel"
           :rules="[noDuplicate]"
           variant="outlined"

--- a/test/cypress/e2e/components/task.cy.js
+++ b/test/cypress/e2e/components/task.cy.js
@@ -107,6 +107,22 @@ describe("components", ()=>{
     /**
   Task コンポーネントの基本機能動作確認
   コンポーネント共通機能確認
+  input files表示
+  試験確認内容：input/output filesパネルを開いた時にinput filesの入力欄にフォーカスが当たっていることを確認
+     */
+    it("input files表示-input filesの入力欄に自動でフォーカスが当たっていることを確認", ()=>{
+      cy.get("[data-cy=\"component_property-in_out_files-panel_title\"]", { timeout: 10000 })
+        .scrollIntoView()
+        .click({ force: true });
+      cy.get("[data-cy=\"component_property-input_files-list_form\"]")
+        .find("[data-cy=\"list_form-add-text_field\"]")
+        .find("input")
+        .should("be.focused");
+    });
+
+    /**
+  Task コンポーネントの基本機能動作確認
+  コンポーネント共通機能確認
   input files入力
   試験確認内容：input filesが入力できることを確認
      */
@@ -508,6 +524,23 @@ describe("components", ()=>{
         .should("exist");
       cy.get("[data-cy=\"file_browser-treeview-treeview\"]").contains("test-b")
         .should("exist");
+    });
+
+    /**
+  Task コンポーネントの基本機能動作確認
+  コンポーネント共通機能確認
+  ファイル操作エリア
+  新規ファイル作成ダイアログ表示
+  試験確認内容：新規ファイル名の入力欄に自動でフォーカスが当たっていることを確認
+     */
+    it("ファイル操作エリア-新規ファイル作成ダイアログ表示-ファイル名入力欄に自動でフォーカスが当たっていることを確認", ()=>{
+      cy.get("[data-cy=\"component_property-files-panel_title\"]", { timeout: 10000 })
+        .scrollIntoView()
+        .click({ force: true });
+      cy.get("[data-cy=\"file_browser-new_file-btn\"]").click({ force: true });
+      cy.get("[data-cy=\"file_browser-dialog-dialog\"]").should("be.visible");
+      cy.get("[data-cy=\"file_browser-input-text_field\"]").find("input")
+        .should("be.focused");
     });
 
     /**


### PR DESCRIPTION
## Summary

Fixes GitLab issue #959: テキストボックスが表示された時にフォーカスが移動しない
("Focus doesn't move to the textbox when it appears", e.g. when entering a new file name; follow-up: the same is wanted for the inputFile add field in the Task property drawer's input/output files section).

- The "new file / new directory / rename" text input in the file browser dialog (`fileBrowser.vue`) now receives keyboard focus automatically when the dialog opens, using the same `autofocus` convention already used by `passwordDialog.vue`.
- The "add input file" text field in `listForm.vue` (used by the Task property drawer's input-files list, both the combined input/output files panel and the Viewer-only input-file-setting panel) now focuses itself once, right after mount, via a `ref` + `nextTick()` call. Vuetify's built-in `autofocus` prop was tried first but its IntersectionObserver-based focus, tied to the accordion-panel-open animation frame, raced with the sibling output-files list-form rendered in the same panel — interrupting mid-keystroke typing into the output field. The explicit one-time ref-based focus avoids that race.
- `outputFiles` list-form deliberately does *not* get autofocus, to avoid two competing autofocus targets in the same panel; only `inputFiles`, as requested in the issue.

## Test plan

- Added two Cypress e2e tests in `test/cypress/e2e/components/task.cy.js`:
  - new-file dialog: asserts the file name input has DOM focus (`cy.focused()`) immediately after the dialog opens, without clicking into it.
  - input/output files panel: asserts the inputFiles list-form's add field has DOM focus immediately after expanding the panel.
- Confirmed red: pushed the tests alone first (commit `test: add e2e checks...`) — both new tests failed with `expected ... to be 'focused'`, all other tests passed.
- Confirmed green: pushed the fix — both new tests pass. Full Cypress Tests suite, `run UT`, and `run UT on windows` are green except for:
  - `run UT`'s `backup` job: fails on this fork by design (missing GitLab backup credentials on `so5/OPEN-WHEEL`, unrelated to the change).
  - A single pre-existing, reproducible flake in `stepjob.cy.js` ("削除ボタン表示確認（input file）", an `mdi-delete` visibility timeout) unrelated to any file touched by this PR — reproduced identically across two reruns.