### PR TITLE
fix: flush pending debounced text-editor saves before the pre-run auto-commit (#999)

### DIFF
--- a/server/app/handlers/rapid.js
+++ b/server/app/handlers/rapid.js
@@ -43,29 +43,58 @@ export async function onSaveFile(projectRootDir, filename, dirname, content, cb)
 
   //Store pending save info
   const pendingSave = {
+    projectRootDir,
+    absPath,
     content,
     callbacks: saveFileTimers.has(fileKey) ? [...saveFileTimers.get(fileKey).callbacks, cb] : [cb],
     timer: null
   };
 
   //Set new timer
-  pendingSave.timer = setTimeout(async ()=>{
-    try {
-      await saveFile(absPath, pendingSave.content);
-      //Call all pending callbacks with success
-      pendingSave.callbacks.forEach((callback)=>{
-        return callback(true);
-      });
-    } catch (err) {
-      getLogger(projectRootDir).warn(projectRootDir, "saveFile event failed", err);
-      //Call all pending callbacks with error
-      pendingSave.callbacks.forEach((callback)=>{
-        return callback(err);
-      });
-    } finally {
-      saveFileTimers.delete(fileKey);
-    }
+  pendingSave.timer = setTimeout(()=>{
+    flushPendingSave(fileKey, pendingSave);
   }, SAVE_FILE_DEBOUNCE_MS);
 
   saveFileTimers.set(fileKey, pendingSave);
 };
+
+async function flushPendingSave(fileKey, pendingSave) {
+  try {
+    await saveFile(pendingSave.absPath, pendingSave.content);
+    //Call all pending callbacks with success
+    pendingSave.callbacks.forEach((callback)=>{
+      return callback(true);
+    });
+  } catch (err) {
+    getLogger(pendingSave.projectRootDir).warn(pendingSave.projectRootDir, "saveFile event failed", err);
+    //Call all pending callbacks with error
+    pendingSave.callbacks.forEach((callback)=>{
+      return callback(err);
+    });
+  } finally {
+    //only delete if this is still the pending save registered under fileKey
+    //(a newer onSaveFile call may already have replaced it)
+    if (saveFileTimers.get(fileKey) === pendingSave) {
+      saveFileTimers.delete(fileKey);
+    }
+  }
+}
+
+/**
+ * Immediately flush (write + git add) any debounced text-editor saves still pending
+ * for the given project, instead of waiting for their debounce timer to fire.
+ * Intended to be called before the pre-run auto-commit so recently-edited files are
+ * not missed by the "auto saved: project starting/continuing" commit.
+ * @param {string} projectRootDir - project's root path
+ * @returns {Promise<void>} resolves once all pending saves for this project are flushed
+ */
+export async function flushPendingSaves(projectRootDir) {
+  const prefix = `${projectRootDir}:`;
+  const targets = [...saveFileTimers.entries()].filter(([fileKey])=>{
+    return fileKey.startsWith(prefix);
+  });
+  await Promise.all(targets.map(([fileKey, pendingSave])=>{
+    clearTimeout(pendingSave.timer);
+    return flushPendingSave(fileKey, pendingSave);
+  }));
+}

--- a/server/app/handlers/workflowEditor.js
+++ b/server/app/handlers/workflowEditor.js
@@ -38,6 +38,7 @@ import { getComponentDir } from "../core/componentJsonIO.js";
 import { sendWorkflow, sendProjectJson, sendComponentTree } from "./senders.js";
 import { convertPathSep } from "../core/pathUtils.js";
 import { updateComponent, updateComponentPos } from "../core/updateComponent.js";
+import { flushPendingSaves } from "./rapid.js";
 
 /**@type {Map<string, SBS>} */
 const projectEditQueues = new Map();
@@ -81,6 +82,10 @@ export async function stopProjectEdits(projectRootDir) {
   //guarantees all pending writes are flushed before validateComponents reads them.
   await queue.qsubAndWait({ exec: async ()=>{} }).catch(()=>{});
   queue.stop();
+  //the in-app text editor's saveFile is debounced independently of this queue (see
+  //rapid.js#onSaveFile), so a save that is still pending when the project starts would
+  //otherwise be missed by the auto-commit taken right after this call returns
+  await flushPendingSaves(projectRootDir);
 }
 
 /**

--- a/server/test/app/handlers/projectController.js
+++ b/server/test/app/handlers/projectController.js
@@ -17,6 +17,7 @@ chai.use(chaiAsPromised);
 
 //testee
 import { _internal } from "../../../app/handlers/projectController.js";
+import { onSaveFile } from "../../../app/handlers/rapid.js";
 
 //helper functions
 import { _internal as coreProjectControllerInternal } from "../../../app/core/projectController.js";
@@ -30,6 +31,7 @@ import { updateComponentProperty } from "../../testUtil.js";
 import { eventEmitters } from "../../../app/core/global.js";
 import { scriptName, scriptHeader, pwdCmd, exit } from "../../testScript.js";
 import { onUpdateComponent } from "../../../app/handlers/workflowEditor.js";
+import { gitAdd, gitCommit, gitPromise } from "../../../app/core/gitOperator2.js";
 
 const scriptPwd = `${scriptHeader}\n${pwdCmd}`;
 
@@ -206,6 +208,37 @@ describe("project Controller handler UT", function () {
       projectJson = await getProjectJson(projectRootDir);
       expect(projectJson.state).to.equal("not-started");
       expect(projectJson.readOnly).to.not.equal(true);
+    });
+  });
+
+  describe("[reproduction] issue #999 - a text-editor save that is still in flight when the project starts", ()=>{
+    const targetFilename = "editedByTextEditor.txt";
+    const initialContent = "initial content written before the project starts\n";
+    const editedContent = "content edited via the in-app text editor\n";
+
+    beforeEach(async ()=>{
+      //simulate a file that already exists in the project and is tracked by git,
+      //as if it had been created and committed on a previous occasion
+      await fs.outputFile(path.join(projectRootDir, targetFilename), initialContent);
+      await gitAdd(projectRootDir, targetFilename);
+      await gitCommit(projectRootDir, "add file to be edited later");
+    });
+
+    it("should include the text-editor's edited content in the 'auto saved: project starting' commit even when onRunProject is triggered immediately after saving (no await)", async ()=>{
+      const saveFileCb = sinon.stub();
+
+      //this reproduces a real client interaction: the text editor's "saveFile" socket event is
+      //fired, but rapid.js#onSaveFile debounces the actual write+gitAdd by SAVE_FILE_DEBOUNCE_MS
+      //(10 seconds) internally and only resolves its callback once that timer fires. The client
+      //does not (and, realistically, often will not) wait for that ack before letting the user
+      //immediately click "run project" - so intentionally do NOT await/settle saveFileCb here.
+      onSaveFile(projectRootDir, targetFilename, projectRootDir, editedContent, saveFileCb);
+
+      const ack = sinon.stub();
+      await _internal.onRunProject("test-client-id", projectRootDir, ack);
+
+      const committedContent = await gitPromise(projectRootDir, ["show", `HEAD:${targetFilename}`], projectRootDir);
+      expect(committedContent).to.equal(editedContent);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `rapid.js#onSaveFile` debounces the actual write+gitAdd by `SAVE_FILE_DEBOUNCE_MS` (10s), only resolving its callback once the timer fires.
- `stopProjectEdits()` (called by `runValidationPhase` right before the "auto saved: project starting/continuing" commit in `onRunProject`/`onContinueProject`) only waited on the separate project-edit queue used for component JSON writes — it had no way to know about these debounced text-editor saves. A save still in flight when the user clicks "run" could be silently dropped from that commit.
- Added `rapid.js#flushPendingSaves(projectRootDir)`, which immediately flushes (write + git add) any pending debounced saves for a project, and wired it into `stopProjectEdits()` right after the edit queue drains.
- Includes the reproduction test for #999 (was failing before this fix, passes now).

## Test plan
- [x] `npx mocha server/test/app/handlers/projectController.js` — 4 passing
- [x] `npx mocha server/test/app/handlers/workflowEditor.js` — 12 passing
- [x] `npm run test -w server` (full suite via docker) — 1538 passing, 2 pending, 0 failing