### PR TITLE
fix: exclude pos from updateComponent()'s patch to avoid reverting a concurrent drag-move (#910)

### DIFF
--- a/server/app/core/updateComponent.js
+++ b/server/app/core/updateComponent.js
@@ -292,8 +292,12 @@ async function updateComponent(projectRootDir, ID, updated) {
   let newName = null;
   const promises = [];
 
-  //remove next, previous, else, inputFiles, and outputFiles from patch
-  //because these props must be changed by dedicated API (ex. addLink, addInputFile, addOutputFile)
+  //remove next, previous, else, inputFiles, outputFiles, and pos from patch
+  //because these props must be changed by dedicated API (ex. addLink, addInputFile, addOutputFile,
+  //updateComponentPos). pos in particular is excluded because the caller's "updated" object is
+  //often a client-side working copy (e.g. the properties panel) that does not track pos changes
+  //made concurrently by dragging the component on the graph (issue #910) - applying pos from such
+  //a stale patch would silently revert a drag-move that already landed on disk.
   const sanitizedPatch = patch.filter((e)=>{
     if (e.path[0] === "name") {
       if (!isValidName(e.value)) {
@@ -305,7 +309,7 @@ async function updateComponent(projectRootDir, ID, updated) {
       promises.push(_internal.setUploadOndemandOutputFile(projectRootDir, ID));
       return false;
     }
-    return !["next", "previous", "else", "inputFiles", "outputFiles"].includes(e.path[0]);
+    return !["next", "previous", "else", "inputFiles", "outputFiles", "pos"].includes(e.path[0]);
   });
 
   await Promise.all(promises);

--- a/server/test/app/core/updateComponent.js
+++ b/server/test/app/core/updateComponent.js
@@ -72,6 +72,40 @@ describe("updateComponent UT", function () {
       expect(readFromFile.description).to.equal("hoge");
       expect(readFromFile.script).to.equal("run.sh");
     });
+    it("should not revert pos updated by updateComponentPos when updateComponent() is called afterward with a stale pos (issue #910)", async ()=>{
+      //Reproduces GitLab issue #910:
+      //"if a component's properties panel is open, moving the component doesn't get persisted"
+      //
+      //Scenario this mimics:
+      //1. user opens the properties panel for task0. the client keeps a local
+      //working copy of task0 (Vuex `copySelectedComponent`) to back the panel's form fields.
+      //2. while the panel is open, the user drags task0 on the graph. the client
+      //sends ONLY `updateComponentPos` (position-only), which is written to
+      //disk immediately and does not touch the working copy of the panel's
+      //other fields (only "pos" is excluded from the panel's diff/update logic).
+      //3. the user edits another field in the still-open panel and commits it,
+      //which triggers `updateComponent()`. this call carries the panel's stale
+      //working copy, whose `pos` still holds the pre-drag value because the
+      //panel's local copy is only kept in sync for non-pos fields.
+      //
+      //Expected: the position written by updateComponentPos() in step 2 must survive
+      //the later updateComponent() call in step 3; only "description" should change.
+      const staleCopy = structuredClone(task0);
+
+      const newPos = { x: 123, y: 456 };
+      await updateComponent.updateComponentPos(projectRootDir, task0.ID, newPos);
+
+      let readFromFile = await fs.readJson(path.join(projectRootDir, task0.name, componentJsonFilename));
+      expect(readFromFile.pos).to.deep.equal(newPos);
+
+      //staleCopy.pos still holds the original (pre-drag) position
+      staleCopy.description = "hoge";
+      await updateComponent.updateComponent(projectRootDir, task0.ID, staleCopy);
+
+      readFromFile = await fs.readJson(path.join(projectRootDir, task0.name, componentJsonFilename));
+      expect(readFromFile.description).to.equal("hoge");
+      expect(readFromFile.pos).to.deep.equal(newPos);
+    });
     it("should change to default value if some property is dropped", async ()=>{
       const updated = structuredClone(task0);
       updated.description = "hoge";


### PR DESCRIPTION
## Summary
- While a component's properties panel is open, the client's local working copy (Vuex `copySelectedComponent`) doesn't track `pos` changes made by dragging the component on the graph — only `updateComponentPos()` (position-only) is sent for that.
- If the user then edits another field in the still-open panel, `updateComponent()` is called with the panel's stale working copy, whose `pos` still holds the pre-drag value. `diff(targetComponent, updated)` included that stale `pos` in the patch and applied it, silently reverting the drag-move that had already landed on disk.
- `pos` is now excluded from the patch the same way `next`/`previous`/`else`/`inputFiles`/`outputFiles` already are, since it must only be changed via the dedicated `updateComponentPos()` API.
- Includes the reproduction test for #910 (was failing before this fix, passes now).

## Test plan
- [x] `npx mocha server/test/app/core/updateComponent.js` — 73 passing
- [x] `npm run test -w server` (full suite via docker) — 1536 passing, 2 pending, 0 failing (3 known pre-existing `#remote job`/mock-PBS flaky failures reproduce identically on unmodified dev2025 and are unrelated to this change — verified on a clean control checkout)