### PR TITLE
fix: sync parameterStudy's descendant states from an executed instance into its template after finishing (#935)

### DIFF
--- a/server/WHEEL_TEST_TMP/.gitignore
+++ b/server/WHEEL_TEST_TMP/.gitignore
@@ -1,0 +1,2 @@
+
+wheel.log

--- a/server/app/core/componentState.js
+++ b/server/app/core/componentState.js
@@ -46,4 +46,37 @@ export async function setComponentStateR(projectRootDir, dir, state, doNotAdd = 
   return Promise.all(p);
 };
 
+/**
+ * copy each descendant component's state from srcDir into the matching descendant under dstDir
+ * intended for parameterStudy: its "template" directory (dstDir) is only ever copied FROM to
+ * create each parameter instance and is never itself executed, so its descendants' component
+ * JSON files are left permanently "not-started" unless explicitly synced from one of the
+ * executed instance directories (srcDir) after the run finishes
+ * @param {string} projectRootDir - project's root path
+ * @param {string} srcDir - directory to read state from (e.g. an executed parameterStudy instance)
+ * @param {string} dstDir - directory to write state into (e.g. the parameterStudy template)
+ * @returns {Promise} - resolved when all matching componentJSON files are updated
+ */
+export async function syncComponentStateFrom(projectRootDir, srcDir, dstDir) {
+  const filenames = await _internal.glob(path.join(srcDir, "**", componentJsonFilename));
+  const p = filenames.map(async (filename)=>{
+    const relativePath = path.relative(srcDir, filename);
+    const dstFilename = path.join(dstDir, relativePath);
+    if (!await _internal.fs.pathExists(dstFilename)) {
+      return null;
+    }
+    const [srcComponent, dstComponent] = await Promise.all([
+      _internal.readJsonGreedy(filename),
+      _internal.readJsonGreedy(dstFilename)
+    ]);
+    if (dstComponent.state === srcComponent.state) {
+      return null;
+    }
+    dstComponent.state = srcComponent.state;
+    const dstComponentDir = path.dirname(dstFilename);
+    return _internal.writeComponentJson(projectRootDir, dstComponentDir, dstComponent, true);
+  });
+  return Promise.all(p);
+}
+
 export { _internal };

--- a/server/app/core/dispatcher.js
+++ b/server/app/core/dispatcher.js
@@ -21,7 +21,7 @@ import { deliverFile, deliverFilesOnRemote, deliverFilesFromRemote, deliverFiles
 import { paramVecGenerator, getParamSize, getFilenames, getParamSpacev2 } from "./parameterParser.js";
 import { isLocal } from "../../../common/checkComponent.js";
 import { isSameRemoteHost, translateSharedPath } from "./componentHostOperations.js";
-import { setComponentStateR } from "./componentState.js";
+import { setComponentStateR, syncComponentStateFrom } from "./componentState.js";
 import { writeComponentJson, readComponentJson, readComponentJsonByID } from "./componentJsonIO.js";
 import { isInitialComponent, removeDuplicatedComponent, hasStoragePath } from "./workflowComponent.js";
 import { getChildren } from "./workflowUtil.js";
@@ -970,6 +970,12 @@ class Dispatcher extends EventEmitter {
       ee.emit("componentStateChanged", component);
       return writeComponentJson(this.projectRootDir, templateRoot, component, true);
     });
+    //templateRoot's descendants (e.g. the task shown when navigating into this PS component)
+    //are only ever copied FROM to create each parameter instance and are never themselves
+    //executed, so pick one instance to sync their post-run state back from once the run
+    //finishes (issue #935). prefer a failed instance so a failure is visible there too.
+    let representativeInstanceRoot = null;
+    let representativeIsFailure = false;
     for (const paramVec of paramVecGenerator(paramSpace)) {
       const params = paramVec.reduce((p, c)=>{
         p[c.key] = c.value;
@@ -1044,6 +1050,10 @@ class Dispatcher extends EventEmitter {
           } else {
             logWarn(this.projectRootDir, `${this.cwfDir}/${component.name}`, "child state is illegal", newComponent.state);
           }
+          if (representativeInstanceRoot === null || (newComponent.state === "failed" && !representativeIsFailure)) {
+            representativeInstanceRoot = instanceRoot;
+            representativeIsFailure = newComponent.state === "failed";
+          }
           //Emit component state changed for the PS/foreach component itself
           const ee = eventEmitters.get(this.projectRootDir);
           if (ee) {
@@ -1054,6 +1064,9 @@ class Dispatcher extends EventEmitter {
       promises.push(p);
     }
     await Promise.all(promises);
+    if (representativeInstanceRoot !== null) {
+      await syncComponentStateFrom(this.projectRootDir, representativeInstanceRoot, templateRoot);
+    }
     logDebug(this.projectRootDir, `${this.cwfDir}/${component.name}`, "gather files");
 
     //gather from all instance dirs even restarting.

--- a/test/cypress/e2e/issue935PsStatusIcons.cy.js
+++ b/test/cypress/e2e/issue935PsStatusIcons.cy.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Center for Computational Science, RIKEN All rights reserved.
+ * Copyright (c) Research Institute for Information Technology(RIIT), Kyushu University. All rights reserved.
+ * See License in the project root for the license information.
+ */
+/**
+ * issue #935 - reproduction test
+ * 実行終了時(finishedになった時)にコンポーネントのステータスが正しく表示されない
+ * (PS component shows "running" forever, nested task's icon never shows up)
+ */
+describe("issue935 - PS + task status icons after project finished", ()=>{
+  const DEF_COMPONENT_PS = "parameterStudy";
+  const DEF_COMPONENT_TASK = "task";
+  const PS_NAME = "PS0";
+  const TASK_NAME = "task0";
+  const LOCAL_HOST = "localhost";
+  const SCRIPT_NAME = "task0.sh";
+  const SCRIPT_BODY = "echo \"hello\" > result.txt";
+  const TARGET_FILE = "run.sh";
+
+  before(()=>{
+    return cy.removeAllProjects();
+  });
+
+  after(()=>{
+    return cy.removeAllProjects();
+  });
+
+  beforeEach(()=>{
+    cy.viewport("macbook-16");
+    return cy.createAndOpenProject();
+  });
+
+  function getStoreState() {
+    return cy.window().then((win)=>{
+      const store = win.document.querySelector("#app").__vue_app__.config.globalProperties.$store;
+      return store.state;
+    });
+  }
+
+  //retries (like a normal cy .should()) until the named component reaches "finished",
+  //or times out - so we are not racing our own read against the async socket.io update
+  function waitForComponentState(name, expectedState, timeout = 20000) {
+    return cy.window({ timeout }).should((win)=>{
+      const store = win.document.querySelector("#app").__vue_app__.config.globalProperties.$store;
+      const target = store.state.currentComponent && store.state.currentComponent.descendants
+        ? store.state.currentComponent.descendants.find((c)=>{
+          return c.name === name;
+        })
+        : null;
+      expect(target, `${name} present in currentComponent.descendants`).to.exist;
+      expect(target.state, `${name} component state`).to.equal(expectedState);
+    }).then(()=>{
+      return getStoreState().then((state)=>{
+        return state.currentComponent.descendants.find((c)=>{
+          return c.name === name;
+        });
+      });
+    });
+  }
+
+  it("PS component and the task inside it both show \"finished\" status after the project reaches finished", ()=>{
+    //create PS0 at root - property panel opens automatically
+    cy.createComponent(DEF_COMPONENT_PS, PS_NAME, 501, 500);
+
+    //create a real file "run.sh" inside PS0 so the PS-config target file substitution
+    //has something to read from during real execution
+    cy.createDirOrFile("file", TARGET_FILE, true);
+
+    //configure a single-value parameter (min=max=step=1 => exactly one instance) so the
+    //PS actually iterates once instead of finishing immediately with zero children
+    cy.clickTreeviewItem("[data-cy=\"file_browser-treeview-treeview\"]", "parameterSetting.json");
+    cy.get("[data-cy=\"file_browser-edit_files-btn\"]").click();
+    cy.get("[data-cy=\"target_files-add_target_file-btn\"]").click();
+    cy.get("[data-cy=\"target_files-target_file_name-text_field\"]").type(TARGET_FILE);
+    cy.get("[data-cy=\"target_files-ok-btn\"]").click();
+    cy.get("[data-cy=\"rapid-tab-tab_editor\"]").type("VALUE=value");
+    cy.get("[data-cy=\"rapid-tab-tab_editor\"]").dblclick();
+    cy.get("[data-cy=\"parameter-add_new_parameter_btn\"]").click();
+    cy.get("[data-cy=\"parameter-min-text_field\"]").clear()
+      .type(1);
+    cy.get("[data-cy=\"parameter-max-text_field\"]").clear()
+      .type(1);
+    cy.get("[data-cy=\"parameter-step-text_field\"]").clear()
+      .type(1);
+    cy.get("[data-cy=\"parameter-ok-btn\"]").click();
+
+    //save & close the PS-config editor
+    cy.get("[data-cy=\"workflow-text_editor_close-btn\"]").click();
+    cy.get("body").then(($body)=>{
+      if ($body.find("button:contains(\"Keep changes\")").length) {
+        cy.contains("button", /Keep changes/i).click();
+      }
+    });
+    cy.get("[data-cy=\"workflow-text_editor_close-btn\"]").should("not.exist");
+    cy.closeProperty();
+
+    //enter PS0 and create a real task inside it (this is the "template" that gets copied
+    //into a fresh instance directory for every parameter combination at run time)
+    cy.doubleClickComponentName(PS_NAME);
+    cy.createComponent(DEF_COMPONENT_TASK, TASK_NAME, 501, 500);
+    cy.setupTaskWithScriptAndIO(SCRIPT_NAME, SCRIPT_BODY, "output", "result.txt", LOCAL_HOST);
+    cy.closeProperty();
+
+    //back to root
+    cy.get(".v-breadcrumbs-item").eq(0)
+      .find(".v-btn")
+      .click();
+    cy.get("[data-cy=\"graph-component-row\"]").contains(PS_NAME)
+      .should("exist");
+
+    //run the project to completion
+    cy.get("[data-cy=\"workflow-play-btn\"]", { timeout: 10000 }).click();
+    cy.checkProjectStatus("finished", 60000);
+
+    //--- assertion 1: PS0's own status icon (visible at root, without navigating in) ---
+    //statusIcon.vue only renders its <image> once state !== "not-started", so if the icon
+    //never renders (or the state field is stuck on "running"), it means the client never
+    //received/applied the PS's own final "finished" componentStateChanged update.
+    waitForComponentState(PS_NAME, "finished").then((ps)=>{
+      cy.log(`PS0 state on client = ${JSON.stringify({ state: ps.state, numTotal: ps.numTotal, numFinished: ps.numFinished, numFailed: ps.numFailed })}`);
+      expect(ps.numFinished, "PS0 numFinished").to.equal(1);
+      expect(ps.numFailed, "PS0 numFailed").to.equal(0);
+    });
+
+    cy.get("[data-cy=\"component-component_group-g\"]").contains(PS_NAME)
+      .parents("[data-cy=\"component-component_group-g\"]")
+      .first()
+      .find("[data-cy=\"component_header-rect_rect\"]")
+      .parent()
+      .find("image")
+      .should("have.length", 2); //type icon + status icon (status icon only renders once state !== "not-started")
+
+    //--- assertion 2: the task visible after navigating into PS0 ---
+    cy.doubleClickComponentName(PS_NAME);
+    cy.get("[data-cy=\"graph-component-row\"]").contains(TASK_NAME)
+      .should("exist");
+
+    waitForComponentState(TASK_NAME, "finished").then((task)=>{
+      cy.log(`task0 state as seen inside PS0 = ${task.state}`);
+    });
+
+    cy.get("[data-cy=\"component-component_group-g\"]").contains(TASK_NAME)
+      .parents("[data-cy=\"component-component_group-g\"]")
+      .first()
+      .find("[data-cy=\"component_header-rect_rect\"]")
+      .parent()
+      .find("image")
+      .should("have.length", 2); //type icon + status icon
+  });
+});


### PR DESCRIPTION
## Summary
- A `parameterStudy` component's template directory is only ever copied FROM to create each parameter instance and is never itself executed, so its descendants' (e.g. a nested task's) component JSON files stay permanently `not-started`.
- The client always navigates into this template directory (`getComponentDir` resolves the ID->path mapping set once at component creation, which is never updated for PS instances), so the nested task's status icon appeared stuck at "not-started" forever even after the project finished — unlike the PS component's own icon, which is written directly to the template and updates correctly.
- Added `componentState.js#syncComponentStateFrom()`, called from `dispatcher.js#_PSHandler` once all instances complete, copying state from one representative instance (preferring a failed one, so a failure is visible in the template view too) back into the matching descendants under the template directory.
- Includes the Cypress reproduction test for #935 (was failing before this fix, passes now).

## Test plan
- [x] `npx cypress run --browser chrome --spec cypress/e2e/issue935PsStatusIcons.cy.js` (mock e2e stack) — 1 passing
- [x] `npx mocha server/test/app/core/dispatcher.js server/test/app/core/componentState.js` — 56 passing, incl. the existing "PS in loop" integration test
- [x] `npm run test -w server` (full suite via docker) — 1536 passing, 2 pending, 0 failing (3 known pre-existing `#remote job`/mock-PBS flaky failures reproduce identically on unmodified dev2025 and are unrelated to this change)