### PR TITLE
docs: fix incorrect scope of OOD single-use key section (#956)

### DIFF
--- a/documentMD/user_guide/_reference/2_remotehost_screen/ssh_auth.md
+++ b/documentMD/user_guide/_reference/2_remotehost_screen/ssh_auth.md
@@ -93,65 +93,27 @@ docker run -d \
 {% endcapture %}
 <div class="notice--info">{{ notice-ssh-agent | markdownify }}</div>
 
-### 2.4 OpenOnDemand（Fugaku）の使い捨て鍵を利用した認証
+### 2.4 OpenOnDemand（Fugaku）の使い捨て鍵について
 
 RIKEN-RCCSが提供するFugaku向けOpenOnDemandポータルには、WHEELをインタラクティブアプリとして起動するための
 アプリ定義（[so5/ondemand_fugaku](https://github.com/so5/ondemand_fugaku/tree/main/WHEEL)）が用意されています。
 
-このアプリの起動フォームで `Key Mode` を **`Single-use key pair`** に設定すると、
-WHEELインスタンスが自動的に鍵ペアを生成し、Fugakuログインノードの `~/.ssh/authorized_keys` と
-`~/.ssh/config` を更新します。生成された鍵ペアは、WHEELインスタンス終了時に自動的に無効化される
-使い捨て（一度限り）の鍵です。
-
-#### 自動的に行われる処理
-
-`Single-use key pair` を選択して起動すると、以下の処理が自動的に行われます。
-
-1. WHEELコンテナ起動時（`entrypoint.sh`）に ed25519 鍵ペアが生成される。
-   - 秘密鍵: `/tmp_identify`
-   - 公開鍵: `~/.wheel/wheel_tmp_pubkey`
-2. WHEELサーバの起動が確認された後、生成された公開鍵がFugakuログインノードの
-   `~/.ssh/authorized_keys` に追記される。
-3. `~/.ssh/config` に以下のエントリが追記される。
-
-   ```
-   HOST login.fugaku.r-ccs.riken.jp
-     IdentityFile /tmp_identify
-   ```
-
-4. WHEELインスタンス終了時、上記で追加された `authorized_keys` の1行と
-   `~/.ssh/config` のエントリは自動的に削除される。
-
-#### WHEEL側で手動設定が必要な項目（初回のみ）
-
-上記の処理はFugaku側の認証設定のみを行うものです。「この鍵でどのリモートホストに接続するか」は、
-WHEELのリモートホスト設定ダイアログから**利用者自身が登録する必要があります**。
-
-1. [リモートホスト設定ダイアログ]({{ site.baseurl }}/reference/2_remotehost_screen/)で、
-   Fugakuログインノードを次の内容で新規登録する。
-
-   | 項目 | 設定値 |
-   |------|--------|
-   | Hostname | `login.fugaku.r-ccs.riken.jp` |
-   | User | Fugakuのユーザ名 |
-   | use public key authentication | 有効 |
-   | private key path | `/tmp_identify` |
-
-2. 秘密鍵のパス（`/tmp_identify`）は使い捨て鍵の生成先として常に固定されているため、
-   一度上記の設定を行っておけば、次回以降 `Single-use key pair` モードでWHEELを起動した際にも
-   同じリモートホスト設定をそのまま再利用できます
-   （`remotehost.json` は `~/.wheel/` 配下に保存され、WHEELインスタンスをまたいで保持されるため）。
+このアプリの起動フォームで `Key Mode` を **`Single-use key pair`** に設定すると、WHEELインスタンスは
+Fugaku自身に接続するための鍵ペアを自動的に生成し、Fugakuの `~/.ssh/authorized_keys` に登録します。
+**Fugaku自身をリモートホストとして利用する場合、remotehost.jsonの設定は不要です**
+（WHEELインスタンス終了時に、登録した鍵は自動的に無効化されます）。
 
 {% capture notice-single-use %}
-__注意__
+__使い捨て鍵はFugaku以外の接続には使用できません__
 
-`Single-use key pair` モードで生成される鍵は、WHEELインスタンスが終了すると同時に
-Fugaku側の `authorized_keys` から削除されます。そのため、この鍵を使ったリモートホスト設定は
-**同じOpenOnDemandセッション中のみ**有効です。
+この使い捨て鍵は、あくまでFugaku自身への接続のために生成されるものであり、
+**Fugaku以外の他のリモートホストへの接続には使用できません**。
 
-セッションをまたいで永続的に使用したい場合は、`Your own key pair` モードを選択し、
-[2.2 公開鍵認証（秘密鍵ファイル指定）](#22-公開鍵認証秘密鍵ファイル指定)の手順に従って
-自分自身の鍵ペアを登録してください。
+OpenOnDemand経由で起動したWHEELから、Fugaku以外の別のマシンに接続したい場合は、
+通常の手順（[2.1 パスワード認証](#21-パスワード認証)、
+[2.2 公開鍵認証（秘密鍵ファイル指定）](#22-公開鍵認証秘密鍵ファイル指定)）に従って、
+利用者自身の鍵ペアを用意し、接続先マシンの `authorized_keys` に登録した上で
+リモートホスト設定を行ってください。使い捨て鍵の仕組みはこの手順には関与しません。
 {% endcapture %}
 <div class="notice--warning">{{ notice-single-use | markdownify }}</div>
 


### PR DESCRIPTION
## Summary
- Corrects a factual error introduced in #20: that PR incorrectly claimed users must manually register a remotehost.json entry for Fugaku itself when using OpenOnDemand's `Single-use key pair` mode.
- Actual behavior (per repo owner clarification): using Fugaku itself as a remote host under `Single-use key pair` mode requires **no** remotehost.json setup — it works automatically. The disposable key is scoped only to Fugaku itself and is unrelated to connecting to any other machine; those still need the normal own-key-pair flow already documented in 2.1/2.2.
- Rewrote `documentMD/user_guide/_reference/2_remotehost_screen/ssh_auth.md` §2.4 to state this accurately and concisely.
- Docs-only change, pushed with `[skip ci]`.

## Test plan
- [x] Confirmed the corrected scope directly with the repo owner before writing this version.
- [x] Checked heading/anchor structure stays consistent with the rest of `ssh_auth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)